### PR TITLE
Fix broken DOI links to the Mol* Viewer paper

### DIFF
--- a/index.html
+++ b/index.html
@@ -258,9 +258,9 @@
                 <b>When using Mol*, please cite:</b><br />
                 David Sehnal, Sebastian Bittrich, Mandar Deshpande, Radka Svobodová, Karel Berka, Václav Bazgier, Sameer
                 Velankar, Stephen K Burley, Jaroslav Koča, Alexander S Rose: <a
-                    href="https://doi.org/10.1093/nar/gkab31">Mol* Viewer: modern web app for 3D visualization and
+                    href="https://doi.org/10.1093/nar/gkab314">Mol* Viewer: modern web app for 3D visualization and
                     analysis of large biomolecular structures</a>, <i>Nucleic Acids Research</i>, 2021; <a
-                    href="https://doi.org/10.1093/nar/gkab31">10.1093/nar/gkab31</a>.
+                    href="https://doi.org/10.1093/nar/gkab314">10.1093/nar/gkab31</a>.
             </div>
         </div>
 


### PR DESCRIPTION
`https://doi.org/10.1093/nar/gkab31` -> `https://doi.org/10.1093/nar/gkab314` 

![image](https://user-images.githubusercontent.com/7809/119108460-35bf0c00-b9ee-11eb-9699-f311230c64e1.png)


